### PR TITLE
Add a Loading screen widget

### DIFF
--- a/rousseau_vote/lib/src/providers/login.dart
+++ b/rousseau_vote/lib/src/providers/login.dart
@@ -15,4 +15,8 @@ class Login with ChangeNotifier {
   bool isLoggedIn() {
     return true;
   }
+
+  bool isLoading() {
+    return false;
+  }
 }

--- a/rousseau_vote/lib/src/widgets/loading_screen.dart
+++ b/rousseau_vote/lib/src/widgets/loading_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// A screen to display that a loading is in progress.
+/// Can have a custom 'message' (defaults to 'Loading')
+class LoadingScreen extends StatelessWidget {
+  final String message;
+
+  LoadingScreen({this.message = 'Loading'});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            CircularProgressIndicator(
+              strokeWidth: 5,
+            ),
+            Container(
+              padding: EdgeInsets.only(top: 16),
+              child: Text(
+                this.message,
+                style: TextStyle(fontSize: 32),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/rousseau_vote/lib/src/widgets/logged_screen.dart
+++ b/rousseau_vote/lib/src/widgets/logged_screen.dart
@@ -1,19 +1,32 @@
-
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import 'package:rousseau_vote/src/providers/login.dart';
 import 'package:rousseau_vote/src/screens/login_screen.dart';
+
+import './loading_screen.dart';
 
 // Widget to use for loggedin screens. It checks if the user is logged in. If
 // not it redirects to the login screen.
 class LoggedScreen extends StatelessWidget {
   final Widget screen;
+
   const LoggedScreen(this.screen);
 
   @override
   Widget build(BuildContext context) {
-    final isLoggedIn = Provider.of<Login>(context).isLoggedIn();
-    return isLoggedIn ? screen : LoginScreen();
+    final loginContext = Provider.of<Login>(context);
+
+    if (loginContext.isLoading()) {
+      return LoadingScreen(
+        message: 'Logging In',
+      );
+    }
+
+    if (!loginContext.isLoggedIn()) {
+      return LoginScreen();
+    }
+
+    return screen;
   }
 }


### PR DESCRIPTION
As discussed on PR #43, I'm adding a 'Loading' state to the 'LoggedScreen' widget.

The 'LoadingScreen' widget tries to be as much generic as possible to allow reuse inside other screens as well.