### PR TITLE
Add Localizations support

### DIFF
--- a/rousseau_vote/l10n/it.json
+++ b/rousseau_vote/l10n/it.json
@@ -1,0 +1,4 @@
+{
+  "genericLoading": "Caricamento",
+  "loginLoading": "Accesso in corso"
+}

--- a/rousseau_vote/lib/main.dart
+++ b/rousseau_vote/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:rousseau_vote/src/providers/login.dart';
 
+import 'src/l10n/rousseau_localizations.dart';
 import 'src/screens/login_screen.dart';
 import 'src/screens/poll_details_screen.dart';
 import 'src/screens/polls_screen.dart';
@@ -14,27 +16,32 @@ class RousseauVoteApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Provider<Login>(
-        builder: (context) => Login(),
-        dispose: (context, value) => value.dispose(),
-        child: MaterialApp(
-            title: 'Rousseau Vote',
-            theme: ThemeData(
-              primarySwatch: Colors.red,
-            ),
-            routes: {
-              PollsScreen.routeName: (context) => PollsScreen(),
-              LoginScreen.routeName: (context) => LoginScreen(),
-              RegisterScreen.routeName: (context) => RegisterScreen(),
-              PollDetailsScreen.routeName: (context) {
-                String pollId =
-                ModalRoute
-                    .of(context)
-                    .settings
-                    .arguments as String;
-                return PollDetailsScreen(pollId);
-              },
-            }
-           )
+      builder: (context) => Login(),
+      dispose: (context, value) => value.dispose(),
+      child: MaterialApp(
+          title: 'Rousseau Vote',
+          theme: ThemeData(
+            primarySwatch: Colors.red,
+          ),
+          localizationsDelegates: [
+            RousseauLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: [
+            const Locale('it'),
+          ],
+          routes: {
+            PollsScreen.routeName: (context) => PollsScreen(),
+            LoginScreen.routeName: (context) => LoginScreen(),
+            RegisterScreen.routeName: (context) => RegisterScreen(),
+            PollDetailsScreen.routeName: (context) {
+              String pollId =
+                  ModalRoute.of(context).settings.arguments as String;
+              return PollDetailsScreen(pollId);
+            },
+          }),
     );
   }
 }

--- a/rousseau_vote/lib/src/l10n/rousseau_localizations.dart
+++ b/rousseau_vote/lib/src/l10n/rousseau_localizations.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+class _RousseauLocalizationsDelegate
+    extends LocalizationsDelegate<RousseauLocalizations> {
+  final Locale newLocale;
+
+  const _RousseauLocalizationsDelegate({this.newLocale});
+
+  @override
+  bool isSupported(Locale locale) {
+    return ["it"].contains(locale.languageCode);
+  }
+
+  @override
+  Future<RousseauLocalizations> load(Locale locale) {
+    return RousseauLocalizations.load(newLocale ?? locale);
+  }
+
+  @override
+  bool shouldReload(LocalizationsDelegate<RousseauLocalizations> old) {
+    return true;
+  }
+}
+
+class RousseauLocalizations {
+  Locale locale;
+
+  static Map<dynamic, dynamic> _localisedValues;
+
+  static RousseauLocalizations of(BuildContext context) {
+    return Localizations.of<RousseauLocalizations>(
+        context, RousseauLocalizations);
+  }
+
+  static Future<RousseauLocalizations> load(Locale locale) async {
+    RousseauLocalizations rousseauLocalizations = RousseauLocalizations(locale);
+    String jsonContent = await rootBundle
+        .loadString("l10n/${locale.languageCode}.json");
+    _localisedValues = json.decode(jsonContent);
+    return rousseauLocalizations;
+  }
+
+  static const LocalizationsDelegate<RousseauLocalizations> delegate =
+      _RousseauLocalizationsDelegate();
+
+  RousseauLocalizations(Locale locale) {
+    this.locale = locale;
+    _localisedValues = {};
+  }
+
+  get currentLanguage => locale.languageCode;
+
+  String text(String key) {
+    return _localisedValues[key] ?? "'$key' not found";
+  }
+}

--- a/rousseau_vote/lib/src/widgets/loading_screen.dart
+++ b/rousseau_vote/lib/src/widgets/loading_screen.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:rousseau_vote/src/l10n/rousseau_localizations.dart';
 
 /// A screen to display that a loading is in progress.
 /// Can have a custom 'message' (defaults to 'Loading')
 class LoadingScreen extends StatelessWidget {
-  final String message;
+  final String messageKey;
 
-  LoadingScreen({this.message = 'Loading'});
+  LoadingScreen({this.messageKey = 'genericLoading'});
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +21,7 @@ class LoadingScreen extends StatelessWidget {
             Container(
               padding: EdgeInsets.only(top: 16),
               child: Text(
-                this.message,
+                RousseauLocalizations.of(context).text(this.messageKey),
                 style: TextStyle(fontSize: 32),
               ),
             ),

--- a/rousseau_vote/lib/src/widgets/logged_screen.dart
+++ b/rousseau_vote/lib/src/widgets/logged_screen.dart
@@ -19,7 +19,7 @@ class LoggedScreen extends StatelessWidget {
 
     if (loginContext.isLoading()) {
       return LoadingScreen(
-        message: 'Logging In',
+        messageKey: 'loginLoading',
       );
     }
 

--- a/rousseau_vote/pubspec.lock
+++ b/rousseau_vote/pubspec.lock
@@ -41,11 +41,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cupertino_localizations:
+    dependency: "direct main"
+    description:
+      name: flutter_cupertino_localizations
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.8"
   matcher:
     dependency: transitive
     description:

--- a/rousseau_vote/pubspec.yaml
+++ b/rousseau_vote/pubspec.yaml
@@ -24,6 +24,10 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
   provider: ^2.0.0+1
+  # Localization dependencies
+  flutter_localizations:
+    sdk: flutter
+  flutter_cupertino_localizations: ^1.0.1
 
 dev_dependencies:
   flutter_test:
@@ -42,7 +46,8 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
+  assets:
+    - l10n/it.json
   #  - images/a_dot_burr.jpeg
   #  - images/a_dot_ham.jpeg
 


### PR DESCRIPTION
This PR add Localizations support to the App.

The localized messages are defined inside `l10n` folder as JSON files, currently only `it` is supported and defined inside `l10n/it.json`.

To add new locales just add a new supported `Locale` constant inside `MaterialApp` and add the corresponding JSON file under `l10n` folder (also add the file to the `assets` list on `pubspec.yml`).

