### PR TITLE
Refactoring locales and constants

### DIFF
--- a/rousseau_vote/l10n/it.json
+++ b/rousseau_vote/l10n/it.json
@@ -1,13 +1,10 @@
 {
-  "appTitle": "Rousseau Vote",
+    "loading": "Caricamento",
 
-  "genericLoading": "Caricamento",
-  "loginLoading": "Accesso in corso",
-
-  "email": "Email",
-  "password": "Password",
-  "loginButton": "Entra",
-  "forgotPassword": "Hai dimenticato la password?",
-  "orUpperCase": "OPPURE",
-  "register": "REGISTRATI"
+    "email": "Email",
+    "password": "Password",
+    "password-forgot": "Hai dimenticato la password?",
+    "login-button": "Entra",
+    "register-button": "Registrati",
+    "or": "oppure"
 }

--- a/rousseau_vote/lib/main.dart
+++ b/rousseau_vote/lib/main.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:rousseau_vote/src/providers/login.dart';
 
+import 'src/config/app_constants.dart';
 import 'src/l10n/rousseau_localizations.dart';
 import 'src/screens/login_screen.dart';
 import 'src/screens/poll_details_screen.dart';
@@ -12,39 +13,39 @@ import 'src/screens/register_screen.dart';
 void main() => runApp(RousseauVoteApp());
 
 class RousseauVoteApp extends StatelessWidget {
-  // This widget is the root of your application.
+
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(builder: (_) => Login()),
       ],
-      //builder: (context) => Login(),
       child: MaterialApp(
-          title: 'Rousseau vote',
-          theme: ThemeData(
-            primarySwatch: Colors.red,
-            primaryColor: Color(0xFFD11F25)
-          ),
-          localizationsDelegates: [
-            RousseauLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: [
-            const Locale('it'),
-          ],
-          routes: {
-            PollsScreen.routeName: (context) => PollsScreen(),
-            LoginScreen.routeName: (context) => LoginScreen(),
-            RegisterScreen.routeName: (context) => RegisterScreen(),
-            PollDetailsScreen.routeName: (context) {
-              String pollId =
-                  ModalRoute.of(context).settings.arguments as String;
-              return PollDetailsScreen(pollId);
-            },
-          }),
+        title: APP_NAME,
+        theme: ThemeData(
+          primarySwatch: Colors.red,
+          primaryColor: Color(0xFFE30613)
+        ),
+        localizationsDelegates: [
+          RousseauLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: [
+          const Locale('it'),
+        ],
+        routes: {
+          PollsScreen.routeName: (context) => PollsScreen(),
+          LoginScreen.routeName: (context) => LoginScreen(),
+          RegisterScreen.routeName: (context) => RegisterScreen(),
+          PollDetailsScreen.routeName: (context) {
+            String pollId = ModalRoute.of(context).settings.arguments as String;
+            return PollDetailsScreen(pollId);
+          },
+        }
+      ),
     );
   }
+  
 }

--- a/rousseau_vote/lib/src/l10n/rousseau_localizations.dart
+++ b/rousseau_vote/lib/src/l10n/rousseau_localizations.dart
@@ -5,10 +5,9 @@ import 'dart:ui';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
-class _RousseauLocalizationsDelegate
-    extends LocalizationsDelegate<RousseauLocalizations> {
+class _RousseauLocalizationsDelegate extends LocalizationsDelegate<RousseauLocalizations> {
+  
   final Locale newLocale;
-
   const _RousseauLocalizationsDelegate({this.newLocale});
 
   @override
@@ -25,11 +24,13 @@ class _RousseauLocalizationsDelegate
   bool shouldReload(LocalizationsDelegate<RousseauLocalizations> old) {
     return true;
   }
+
 }
 
 class RousseauLocalizations {
+  
   Locale locale;
-
+  
   static Map<dynamic, dynamic> _localisedValues;
 
   static RousseauLocalizations of(BuildContext context) {
@@ -43,14 +44,12 @@ class RousseauLocalizations {
 
   static Future<RousseauLocalizations> load(Locale locale) async {
     RousseauLocalizations rousseauLocalizations = RousseauLocalizations(locale);
-    String jsonContent = await rootBundle
-        .loadString("l10n/${locale.languageCode}.json");
+    String jsonContent = await rootBundle.loadString("l10n/${locale.languageCode}.json");
     _localisedValues = json.decode(jsonContent);
     return rousseauLocalizations;
   }
 
-  static const LocalizationsDelegate<RousseauLocalizations> delegate =
-      _RousseauLocalizationsDelegate();
+  static const LocalizationsDelegate<RousseauLocalizations> delegate = _RousseauLocalizationsDelegate();
 
   RousseauLocalizations(Locale locale) {
     this.locale = locale;
@@ -62,4 +61,5 @@ class RousseauLocalizations {
   String text(String key) {
     return _localisedValues[key] ?? "'$key' not found";
   }
+
 }

--- a/rousseau_vote/lib/src/providers/login.dart
+++ b/rousseau_vote/lib/src/providers/login.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 class Login with ChangeNotifier {
+  
   var _isLoading = false;
   var _isLogged = false;
 
@@ -31,4 +32,5 @@ class Login with ChangeNotifier {
   bool isLoading() {
     return _isLoading;
   }
+  
 }

--- a/rousseau_vote/lib/src/screens/login_screen.dart
+++ b/rousseau_vote/lib/src/screens/login_screen.dart
@@ -3,13 +3,13 @@ import 'package:flutter/widgets.dart';
 import 'package:rousseau_vote/src/screens/native_login_screen.dart';
 import 'package:rousseau_vote/src/screens/web_login_screen.dart';
 
-import '../config/app_constants.dart' as AppConstants;
+import '../config/app_constants.dart';
 
 class LoginScreen extends StatelessWidget {
   static const routeName = '/login';
 
   @override
   Widget build(BuildContext context) {
-    return AppConstants.USE_NATIVE_LOGIN ? NativeLoginScreen() : WebLoginScreen();
+    return USE_NATIVE_LOGIN ? NativeLoginScreen() : WebLoginScreen();
   }
 }

--- a/rousseau_vote/lib/src/screens/native_login_screen.dart
+++ b/rousseau_vote/lib/src/screens/native_login_screen.dart
@@ -27,7 +27,7 @@ class NativeLoginScreen extends StatelessWidget {
                       RoundedTextField(hintText: RousseauLocalizations.getText(context, 'password'), obscureText: true, enabled: !login.isLoading()),
                       SizedBox(height: 15.0),
                       RoundedButton(
-                        text: RousseauLocalizations.getText(context, 'loginButton'),
+                        text: RousseauLocalizations.getText(context, 'login-button'),
                         loading: login.isLoading(),
                         onPressed: () {
                           login.login();
@@ -38,7 +38,7 @@ class NativeLoginScreen extends StatelessWidget {
               ),
               SizedBox(height: 25.0),
               Text(
-                RousseauLocalizations.getText(context, 'forgotPassword'),
+                RousseauLocalizations.getText(context, 'password-forgot'),
                 style: TextStyle(fontFamily: 'Roboto', fontSize: 16.0),
               ),
               SizedBox(height: 25.0),
@@ -46,7 +46,7 @@ class NativeLoginScreen extends StatelessWidget {
               Row(children: [
                 Expanded(child: Divider(thickness: 2)),
                 Expanded(
-                    child: Text(RousseauLocalizations.getText(context, 'orUpperCase'),
+                    child: Text(RousseauLocalizations.getText(context, 'or').toUpperCase(),
                         textAlign: TextAlign.center,
                         style: TextStyle(
                             fontFamily: 'Roboto',
@@ -57,7 +57,7 @@ class NativeLoginScreen extends StatelessWidget {
               SizedBox(height: 25.0),
               FlatButton(
                 child: Text(
-                  RousseauLocalizations.getText(context, 'register'),
+                  RousseauLocalizations.getText(context, 'register-button').toUpperCase(),
                   style: TextStyle(
                     fontFamily: 'Roboto',
                     fontSize: 20.0,

--- a/rousseau_vote/lib/src/widgets/loading_screen.dart
+++ b/rousseau_vote/lib/src/widgets/loading_screen.dart
@@ -6,7 +6,7 @@ import 'package:rousseau_vote/src/l10n/rousseau_localizations.dart';
 class LoadingScreen extends StatelessWidget {
   final String messageKey;
 
-  LoadingScreen({this.messageKey = 'genericLoading'});
+  LoadingScreen({this.messageKey = 'loading'});
 
   @override
   Widget build(BuildContext context) {

--- a/rousseau_vote/lib/src/widgets/rousseau_logged_scaffold.dart
+++ b/rousseau_vote/lib/src/widgets/rousseau_logged_scaffold.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import '../config/app_constants.dart' as AppConstants;
+
+import '../config/app_constants.dart';
 import 'logged_screen.dart';
 
 // Widget to use for loggedin screens. It checks if the user is logged in. If
@@ -13,7 +14,7 @@ class RousseauLoggedScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return LoggedScreen(
         Scaffold(
-          appBar: AppBar(title: Text(AppConstants.TOOLBAR_TITLE)),
+          appBar: AppBar(title: Text(TOOLBAR_TITLE)),
           body: Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
- Generalized usage of constants in app (starting from app title);
- Removed needless indentations;
- hyphen-case for locales (improve strings' readability).
